### PR TITLE
Use placeholder instead of default

### DIFF
--- a/luasrc/model/cbi/smartdns/smartdns.lua
+++ b/luasrc/model/cbi/smartdns/smartdns.lua
@@ -44,7 +44,7 @@ o.rempty      = false
 o = s:taboption("settings", Value, "server_name", translate("Server Name"), translate("Smartdns server name"))
 o.default     = "smartdns"
 o.datatype    = "hostname"
-o.rempty      = false
+o.rempty      = true
 
 ---- Port
 o = s:taboption("settings", Value, "port", translate("Local Port"), translate("Smartdns local server port"))
@@ -262,7 +262,7 @@ o:value("https", translate("https"))
 o.default     = "udp"
 o.rempty      = false
 
--- Doman addresss
+-- Domain Address
 s = m:section(TypedSection, "smartdns", translate("Domain Address"), 
 	translate("Set Specific domain ip address."))
 s.anonymous = true
@@ -306,7 +306,7 @@ function addr.write(self, section, value)
 	fs.writefile("/etc/smartdns/blacklist-ip.conf", value)
 end
 
--- Doman addresss
+-- Technical Support
 s = m:section(TypedSection, "smartdns", translate("Technical Support"), 
 	translate("If you like this software, please buy me a cup of coffee."))
 s.anonymous = true

--- a/luasrc/model/cbi/smartdns/smartdns.lua
+++ b/luasrc/model/cbi/smartdns/smartdns.lua
@@ -42,7 +42,7 @@ o.rempty      = false
 
 ---- server name
 o = s:taboption("settings", Value, "server_name", translate("Server Name"), translate("Smartdns server name"))
-o.default     = "smartdns"
+o.placeholder = "smartdns"
 o.datatype    = "hostname"
 o.rempty      = true
 


### PR DESCRIPTION
设置成default之后就没办法留空了，因此导致不能使用原机的hostname，而按设计这里是可以留空的。
如果担心教程问题可以修改主repo的smartdns/package/openwrt/files/etc/config/smartdns，这样就不影响了。