### PR TITLE
Add front-end display logs

### DIFF
--- a/htdocs/luci-static/resources/view/smartdns/log.js
+++ b/htdocs/luci-static/resources/view/smartdns/log.js
@@ -1,0 +1,131 @@
+'use strict';
+'require dom';
+'require fs';
+'require poll';
+'require uci';
+'require view';
+'require form';
+
+return view.extend({
+	render: function () {
+		var css = `
+			#log_textarea {
+				margin-top: 10px;
+			}
+			#log_textarea pre {
+				background-color: #f7f7f7;
+				color: #333;
+				padding: 10px;
+				border: 1px solid #ccc;
+				border-radius: 4px;
+				font-family: Consolas, Menlo, Monaco, monospace;
+				font-size: 14px;
+				line-height: 1.5;
+				white-space: pre-wrap;
+				word-wrap: break-word;
+				overflow-y: auto;
+				max-height: 500px;
+			}
+			#.description {
+				background-color: #33ccff;
+			}
+			.cbi-button-danger {
+				background-color: #fff;
+				color: #f00;
+				border: 1px solid #f00;
+				border-radius: 4px;
+				padding: 4px 8px;
+				font-size: 14px;
+				cursor: pointer;
+				margin-top: 10px;
+			}
+			.cbi-button-danger:hover {
+				background-color: #f00;
+				color: #fff;
+			}
+			.cbi-section small {
+				margin-left: 10px;
+			}
+			.cbi-section .cbi-section-actions {
+				margin-top: 10px;
+			}
+			.cbi-section .cbi-section-actions-right {
+				text-align: right;
+			}
+		`;
+
+
+		var log_textarea = E('div', { 'id': 'log_textarea' },
+			E('img', {
+				'src': L.resource(['icons/loading.gif']),
+				'alt': _('Loading...'),
+				'style': 'vertical-align:middle'
+			}, _('Collecting data ...'))
+		);
+
+		var clear_log_button = E('div', {}, [
+			E('button', {
+				'class': 'cbi-button cbi-button-danger',
+				'click': function (ev) {
+					ev.preventDefault();
+					var button = ev.target;
+					button.disabled = true;
+					button.textContent = _('Clear Logs...');
+					fs.exec_direct('/usr/libexec/smartdns-call', ['clear_log'])
+						.then(function () {
+							button.textContent = _('Logs cleared successfully!');
+							setTimeout(function () {
+								button.disabled = false;
+								button.textContent = _('Clear Logs');
+							}, 5000);
+							// 立即刷新日志显示框
+							var log = E('pre', { 'wrap': 'pre' }, [_('Log is clean.')]);
+							dom.content(log_textarea, log);
+						})
+						.catch(function () {
+							button.textContent = _('Failed to clear log.');
+							setTimeout(function () {
+								button.disabled = false;
+								button.textContent = _('Clear Logs');
+							}, 5000);
+						});
+				}
+			}, _('Clear Logs'))
+		]);
+
+
+		poll.add(L.bind(function () {
+			return fs.exec_direct('/usr/libexec/smartdns-call', [ 'tail' ])
+				.then(function (res) {
+					var log = E('pre', { 'wrap': 'pre' }, [res.trim() || _('Log is clean.')]);
+
+					dom.content(log_textarea, log);
+					log.scrollTop = log.scrollHeight;
+				}).catch(function (err) {
+					var log;
+
+					if (err.toString().includes('NotFoundError')) {
+						log = E('pre', { 'wrap': 'pre' }, [_('Log file does not exist.')]);
+					} else {
+						log = E('pre', { 'wrap': 'pre' }, [_('Unknown error: %s').format(err)]);
+					}
+
+					dom.content(log_textarea, log);
+				});
+		}));
+
+		return E('div', { 'class': 'cbi-map' }, [
+			E('style', [css]),
+			E('div', { 'class': 'cbi-section' }, [
+				clear_log_button,
+				log_textarea,
+				E('small', {}, _('Refresh every %s seconds.').format(L.env.pollinterval)),
+				E('div', { 'class': 'cbi-section-actions cbi-section-actions-right' })
+			])
+		]);
+	},
+
+	handleSaveApply: null,
+	handleSave: null,
+	handleReset: null
+});

--- a/po/zh_Hans/smartdns.po
+++ b/po/zh_Hans/smartdns.po
@@ -919,3 +919,37 @@ msgstr "类型"
 #: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:683
 msgid "udp"
 msgstr "udp"
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/log.js:63
+msgid "Collecting data ..."
+msgstr "数据收集中..."
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/log.js:73
+msgid "Clear Logs..."
+msgstr "清除日志..."
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/log.js:76
+msgid "Logs cleared successfully!"
+msgstr "日志清除成功！"
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/log.js:82
+msgid "Log is clean."
+msgstr "日志已清除。"
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/log.js:79
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/log.js:89
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/log.js:93
+msgid "Clear Logs"
+msgstr "清除日志"
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/log.js:122
+msgid "Refresh every %s seconds."
+msgstr "每 %s 秒刷新。"
+
+#: applications/luci-app-smartdns/root/usr/share/luci/menu.d/luci-app-smartdns.json:14
+msgid "Configuration"
+msgstr "配置"
+
+#: applications/luci-app-smartdns/root/usr/share/luci/menu.d/luci-app-smartdns.json:22
+msgid "Logs"
+msgstr "日志"

--- a/root/usr/libexec/smartdns-call
+++ b/root/usr/libexec/smartdns-call
@@ -10,9 +10,9 @@ case "$action" in
         tail)
         # 读取日志
 		tail -n 5000 "$list_file"
-	      ;;
-	      clear_log)
-	      # 清空日志
-	        > $list_file
-	      ;;
+        ;;
+        clear_log)
+        # 清空日志
+		> $list_file
+        ;;
 esac

--- a/root/usr/libexec/smartdns-call
+++ b/root/usr/libexec/smartdns-call
@@ -1,0 +1,18 @@
+#!/bin/sh
+
+action=$1
+shift
+
+log_file="$(uci -q get smartdns.@smartdns[0].log_file)"
+list_file="${log_file:-/var/log/smartdns/smartdns.log}"
+
+case "$action" in
+        tail)
+        # 读取日志
+		      tail -n 5000 "$list_file"
+	      ;;
+	      clear_log)
+	      # 清空日志
+	        > $list_file
+	      ;;
+esac

--- a/root/usr/libexec/smartdns-call
+++ b/root/usr/libexec/smartdns-call
@@ -9,7 +9,7 @@ list_file="${log_file:-/var/log/smartdns/smartdns.log}"
 case "$action" in
         tail)
         # 读取日志
-		      tail -n 5000 "$list_file"
+		tail -n 5000 "$list_file"
 	      ;;
 	      clear_log)
 	      # 清空日志

--- a/root/usr/share/luci/menu.d/luci-app-smartdns.json
+++ b/root/usr/share/luci/menu.d/luci-app-smartdns.json
@@ -1,12 +1,29 @@
 {
 	"admin/services/smartdns": {
 		"title": "SmartDNS",
+		"order": 90,
+		"action": {
+			"type": "firstchild"
+		},
+		"depends": {
+			"acl": [ "luci-app-smartdns" ],
+			"uci": { "smartdns": true }
+		}
+	},
+	"admin/services/smartdns/smartdns": {
+		"title": "Configuration",
+		"order": 50,
 		"action": {
 			"type": "view",
 			"path": "smartdns/smartdns"
-		},
-		"depends": {
-			"uci": { "smartdns": true }
+		}
+	},
+	"admin/services/smartdns/log": {
+		"title": "Logs",
+		"order": 60,
+		"action": {
+			"type": "view",
+			"path": "smartdns/log"
 		}
 	}
 }

--- a/root/usr/share/rpcd/acl.d/luci-app-smartdns.json
+++ b/root/usr/share/rpcd/acl.d/luci-app-smartdns.json
@@ -3,7 +3,9 @@
 		"description": "Grant access to LuCI app smartdns",
 		"read": {
 			"file": {
-				"/etc/smartdns/*": [ "read" ]
+				"/etc/smartdns/*": [ "read" ],
+				"/usr/libexec/smartdns-call tail": [ "exec" ],
+				"/usr/libexec/smartdns-call clear_log": [ "exec" ]
 			},
 			"ubus": {
 				"service": [ "list" ]


### PR DESCRIPTION
Currently, logs can only be viewed through ssh. After front-end logs are displayed, you can view them more easily.