### PR TITLE
Add front-end display logs and update weekly or daily

### DIFF
--- a/htdocs/luci-static/resources/view/smartdns/log.js
+++ b/htdocs/luci-static/resources/view/smartdns/log.js
@@ -1,0 +1,142 @@
+'use strict';
+'require dom';
+'require fs';
+'require poll';
+'require uci';
+'require view';
+'require form';
+'require ui';
+
+return view.extend({
+	render: function () {
+		var css = `
+			#log_textarea {
+				margin-top: 10px;
+			}
+			#log_textarea pre {
+				background-color: #f7f7f7;
+				color: #333;
+				padding: 10px;
+				border: 1px solid #ccc;
+				border-radius: 4px;
+				font-family: Consolas, Menlo, Monaco, monospace;
+				font-size: 14px;
+				line-height: 1.5;
+				white-space: pre-wrap;
+				word-wrap: break-word;
+				overflow-y: auto;
+				max-height: 500px;
+			}
+			#.description {
+				background-color: #33ccff;
+			}
+			.cbi-button-danger {
+				background-color: #fff;
+				color: #f00;
+				border: 1px solid #f00;
+				border-radius: 4px;
+				padding: 4px 8px;
+				font-size: 14px;
+				cursor: pointer;
+				margin-top: 10px;
+			}
+			.cbi-button-danger:hover {
+				background-color: #f00;
+				color: #fff;
+			}
+			.cbi-section small {
+				margin-left: 10px;
+			}
+			.cbi-section .cbi-section-actions {
+				margin-top: 10px;
+			}
+			.cbi-section .cbi-section-actions-right {
+				text-align: right;
+			}
+		`;
+
+
+		var log_textarea = E('div', { 'id': 'log_textarea' },
+			E('img', {
+				'src': L.resource(['icons/loading.gif']),
+				'alt': _('Loading...'),
+				'style': 'vertical-align:middle'
+			}, _('Collecting data ...'))
+		);
+
+		var clear_log_button = E('th', {}, [
+			E('button', {
+				'class': 'cbi-button cbi-button-danger',
+				'click': function (ev) {
+					ev.preventDefault();
+					var button = ev.target;
+					button.disabled = true;
+					button.textContent = _('Clear Logs...');
+					fs.exec_direct('/usr/libexec/smartdns-call', ['clear_log'])
+						.then(function () {
+							button.textContent = _('Logs cleared successfully!');
+							setTimeout(function () {
+								button.disabled = false;
+								button.textContent = _('Clear Logs');
+							}, 5000);
+							// 立即刷新日志显示框
+							var log = E('pre', { 'wrap': 'pre' }, [_('Log is clean.')]);
+							dom.content(log_textarea, log);
+						})
+						.catch(function () {
+							button.textContent = _('Failed to clear log.');
+							setTimeout(function () {
+								button.disabled = false;
+								button.textContent = _('Clear Logs');
+							}, 5000);
+						});
+				}
+			}, _('Clear Logs'))
+		]);
+
+
+		poll.add(L.bind(function () {
+			return fs.exec_direct('/usr/libexec/smartdns-call', [ 'tail' ])
+				.then(function (res) {
+					var log = E('pre', { 'wrap': 'pre' }, [res.trim() || _('Log is clean.')]);
+
+					dom.content(log_textarea, log);
+					log.scrollTop = log.scrollHeight;
+				}).catch(function (err) {
+					var log;
+
+					if (err.toString().includes('NotFoundError')) {
+						log = E('pre', { 'wrap': 'pre' }, [_('Log file does not exist.')]);
+					} else {
+						log = E('pre', { 'wrap': 'pre' }, [_('Unknown error: %s').format(err)]);
+					}
+
+					dom.content(log_textarea, log);
+				});
+		}));
+
+		var back_smartdns_button = E('th', {}, [
+			E('button', {
+				'class': 'cbi-button cbi-button-danger',
+				'click': ui.createHandlerFn(this, function () {
+						window.location.href = "smartdns/smartdns"
+				})
+			}, _('Back SMARTDNS'))
+		]);
+
+		return E('div', { 'class': 'cbi-map' }, [
+			E('style', [css]),
+			E('div', { 'class': 'cbi-section' }, [
+				clear_log_button,
+				back_smartdns_button,
+				log_textarea,
+				E('small', {}, _('Refresh every %s seconds.').format(L.env.pollinterval)),
+				E('div', { 'class': 'cbi-section-actions cbi-section-actions-right' })
+			])
+		]);
+	},
+
+	handleSaveApply: null,
+	handleSave: null,
+	handleReset: null
+});

--- a/htdocs/luci-static/resources/view/smartdns/log.js
+++ b/htdocs/luci-static/resources/view/smartdns/log.js
@@ -79,7 +79,7 @@ return view.extend({
 								button.disabled = false;
 								button.textContent = _('Clear Logs');
 							}, 5000);
-							// 立即刷新日志显示框
+							// Immediately refresh log display box
 							var log = E('pre', { 'wrap': 'pre' }, [_('Log is clean.')]);
 							dom.content(log_textarea, log);
 						})

--- a/htdocs/luci-static/resources/view/smartdns/log.js
+++ b/htdocs/luci-static/resources/view/smartdns/log.js
@@ -119,9 +119,9 @@ return view.extend({
 			E('button', {
 				'class': 'cbi-button cbi-button-danger',
 				'click': ui.createHandlerFn(this, function () {
-						window.location.href = "smartdns/smartdns"
+						window.location.href = "smartdns"
 				})
-			}, _('Back SMARTDNS'))
+			}, _('Back SmartDNS'))
 		]);
 
 		return E('div', { 'class': 'cbi-map' }, [

--- a/htdocs/luci-static/resources/view/smartdns/smartdns.js
+++ b/htdocs/luci-static/resources/view/smartdns/smartdns.js
@@ -135,6 +135,7 @@ return view.extend({
 		s.tab("files", _("Download Files Setting"), _("Download domain list files for domain-rule and include config files, please refresh the page after download to take effect."));
 		s.tab("proxy", _("Proxy Server Settings"));
 		s.tab("custom", _("Custom Settings"));
+		s.tab("log", _("Log Settings"));
 
 		///////////////////////////////////////
 		// Basic Settings
@@ -492,10 +493,22 @@ return view.extend({
 		///////////////////////////////////////
 		// download Files Settings
 		///////////////////////////////////////
-		o = s.taboption("files", form.Flag, "enable_auto_update", _("Enable Auto Update"), _("Enable daily auto update."));
+		o = s.taboption("files", form.Flag, "enable_auto_update", _("Enable Auto Update"), _("Enable daily(week) auto update."));
 		o.rmempty = true;
 		o.default = o.disabled;
 		o.rempty = true;
+
+		o = s.taboption("files", form.ListValue, "auto_update_week_time", _("Update Time (Every Week)"));
+		o.value('*', _('Every Day'));
+		o.value('1', _('Every Monday'));
+		o.value('2', _('Every Tuesday'));
+		o.value('3', _('Every Wednesday'));
+		o.value('4', _('Every Thursday'));
+		o.value('5', _('Every Friday'));
+		o.value('6', _('Every Saturday'));
+		o.value('0', _('Every Sunday'));
+		o.default = "*";
+		o.depends('enable_auto_update', '1');
 
 		o = s.taboption('files', form.ListValue, 'auto_update_day_time', _("Update time (every day)"));
 		for (var i = 0; i < 24; i++)
@@ -607,11 +620,14 @@ return view.extend({
 		o.rmempty = true;
 		o.default = o.disabled;
 
-		o = s.taboption("custom", form.Value, "log_size", _("Log Size"));
+		///////////////////////////////////////
+		// log settings;
+		///////////////////////////////////////
+		o = s.taboption("log", form.Value, "log_size", _("Log Size"));
 		o.rmempty = true;
 		o.placeholder = "default";
 
-		o = s.taboption("custom", form.ListValue, "log_level", _("Log Level"));
+		o = s.taboption("log", form.ListValue, "log_level", _("Log Level"));
 		o.rmempty = true;
 		o.placeholder = "default";
 		o.value("", _("default"));
@@ -623,13 +639,24 @@ return view.extend({
 		o.value("fatal");
 		o.value("off");
 
-		o = s.taboption("custom", form.Value, "log_num", _("Log Number"));
+		o = s.taboption("log", form.Value, "log_num", _("Log Number"));
 		o.rmempty = true;
 		o.placeholder = "default";
 
-		o = s.taboption("custom", form.Value, "log_file", _("Log File"))
+		o = s.taboption("log", form.Value, "log_file", _("Log File"))
 		o.rmempty = true
 		o.placeholder = "/var/log/smartdns/smartdns.log"
+
+		o = s.taboption("log", form.DummyValue, "_view_log", _("View Log"));
+		o.renderWidget = function () {
+			return E('button', {
+				'class': 'btn cbi-button',
+				'id': 'btn_view_log',
+				'click': ui.createHandlerFn(this, function () {
+					window.location.href = "smartdns/log";
+				})
+			}, [_("View Log")]);
+		}
 
 		////////////////
 		// Upstream servers;

--- a/po/zh_Hans/smartdns.po
+++ b/po/zh_Hans/smartdns.po
@@ -964,3 +964,37 @@ msgstr "类型"
 #: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:710
 msgid "udp"
 msgstr "udp"
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/log.js:74
+msgid "Clear Logs..."
+msgstr "清除日志..."
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/log.js:77
+msgid "Logs cleared successfully!"
+msgstr "日志清除成功！"
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/log.js:83
+msgid "Log is clean."
+msgstr "日志已清除。"
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/log.js:80
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/log.js:90
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/log.js:94
+msgid "Clear Logs"
+msgstr "清除日志"
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/log.js:87
+msgid "Failed to clear log."
+msgstr "清除日志失败。"
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/log.js:109
+msgid "Log file does not exist."
+msgstr "日志文件不存在。"
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/log.js:124
+msgid "Back SmartDNS"
+msgstr "返回 SmartDNS"
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/log.js:133
+msgid "Refresh every %s seconds."
+msgstr "每 %s 秒刷新。"

--- a/po/zh_Hans/smartdns.po
+++ b/po/zh_Hans/smartdns.po
@@ -10,73 +10,73 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 "X-Generator: Weblate 4.16.2-dev\n"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:798
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:825
 msgid "Additional Args for upstream dns servers"
 msgstr "额外的上游 DNS 服务器参数"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:892
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:1096
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:919
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:1123
 msgid ""
 "Additional Flags for rules, read help on domain-rule for more information."
 msgstr "额外的规则标识，具体参考domain-rule的帮助说明。"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:891
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:1095
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:918
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:1122
 msgid "Additional Rule Flag"
 msgstr "额外规则标识"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:346
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:479
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:797
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:347
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:480
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:824
 msgid "Additional Server Args"
 msgstr "额外的服务器参数"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:347
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:480
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:348
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:481
 msgid ""
 "Additional server args, refer to the help description of the bind option."
 msgstr "额外的服务器参数，参考bind选项的帮助说明。"
 
 #: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:132
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:645
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:672
 msgid "Advanced Settings"
 msgstr "高级设置"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:253
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:254
 msgid ""
 "Attempts to serve old responses from cache with a TTL of 0 in the response "
 "without waiting for the actual resolution to finish."
 msgstr "查询性能优化，有请求时尝试回应TTL为0的过期记录，以避免查询等待。"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:161
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:162
 msgid "Automatically Set Dnsmasq"
 msgstr "自动设置Dnsmasq"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:161
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:162
 msgid "Automatically set as upstream of dnsmasq when port changes."
 msgstr "端口更改时自动设为 dnsmasq 的上游。"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:229
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:230
 msgid "Bind Device"
 msgstr "绑定到设备"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:234
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:235
 msgid "Bind Device Name"
 msgstr "绑定的设备名称"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:1004
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:1031
 msgid "Block domain"
 msgstr "屏蔽域名"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:1004
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:1031
 msgid "Block domain."
 msgstr "屏蔽域名。"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:262
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:263
 msgid "Cache Persist"
 msgstr "持久化缓存"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:258
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:259
 msgid "Cache Size"
 msgstr "缓存大小"
 
@@ -84,21 +84,21 @@ msgstr "缓存大小"
 msgid "Collecting data ..."
 msgstr "正在收集数据..."
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:1106
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:1133
 msgid ""
 "Configure IP blacklists that will be filtered from the results of specific "
 "DNS server."
 msgstr "配置需要从指定域名服务器结果过滤的IP黑名单。"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:935
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:962
 msgid "Configure block domain list."
 msgstr "配置屏蔽域名列表。"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:956
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:983
 msgid "Configure domain rule list."
 msgstr "配置域名规则列表。"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:906
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:933
 msgid "Configure forwarding domain name list."
 msgstr "配置分流域名列表。"
 
@@ -106,44 +106,48 @@ msgstr "配置分流域名列表。"
 msgid "Custom Settings"
 msgstr "自定义设置"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:817
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:138
+msgid "Log Settings"
+msgstr "日志设置"
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:838
 msgid "DNS Block Setting"
 msgstr "域名屏蔽设置"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:810
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:837
 msgid "DNS Forwarding Setting"
 msgstr "域名分流设置"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:654
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:681
 msgid "DNS Server Name"
 msgstr "DNS服务器名称"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:681
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:708
 msgid "DNS Server group"
 msgstr "服务器组"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:819
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:973
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:846
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:1000
 msgid "DNS Server group belongs to, such as office, home."
 msgstr "设置服务器组，例如office，home。"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:657
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:684
 msgid "DNS Server ip"
 msgstr "DNS服务器IP"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:662
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:689
 msgid "DNS Server port"
 msgstr "DNS服务器端口"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:671
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:698
 msgid "DNS Server type"
 msgstr "协议类型"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:258
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:259
 msgid "DNS domain result cache size"
 msgstr "缓存DNS的结果，缓存大小，配置零则不缓存。"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:487
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:488
 msgid "DNS64"
 msgstr "DNS64"
 
@@ -151,7 +155,7 @@ msgstr "DNS64"
 msgid "DNS64 Server Settings"
 msgstr "DNS64服务器配置"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:566
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:579
 msgid "Description"
 msgstr "描述"
 
@@ -159,72 +163,72 @@ msgstr "描述"
 msgid "Dnsmasq Forwarded To Smartdns Failure"
 msgstr "重定向dnsmasq到smartdns失败"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:725
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:752
 msgid "Do not check certificate."
 msgstr "不校验证书的合法性。"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:397
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:844
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:398
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:871
 msgid "Do not check speed."
 msgstr "禁用测速。"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:813
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:840
 msgid "Domain Address"
 msgstr "域名地址"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:906
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:925
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:933
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:962
 msgid "Domain List"
 msgstr "域名列表"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:897
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:925
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:997
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:924
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:952
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:1024
 msgid "Domain List File"
 msgstr "域名列表文件"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:812
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:955
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:839
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:982
 msgid "Domain Rule List"
 msgstr "域名规则列表"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:971
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:998
 msgid "Domain Rule Name"
 msgstr "域名规则名称"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:806
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:833
 msgid "Domain Rules"
 msgstr "域名规则"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:806
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:833
 msgid "Domain Rules Settings"
 msgstr "域名规则设置"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:324
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:325
 msgid "Domain TTL"
 msgstr "域名TTL"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:336
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:337
 msgid "Domain TTL Max"
 msgstr "域名TTL最大值"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:328
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:329
 msgid "Domain TTL Min"
 msgstr "域名TTL最小值"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:246
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:247
 msgid "Domain prefetch"
 msgstr "域名预加载"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:1165
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:1192
 msgid "Donate"
 msgstr "捐助"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:1164
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:1191
 msgid "Donate to smartdns"
 msgstr "捐助smartdns项目"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:532
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:545
 msgid "Download Files"
 msgstr "下载文件"
 
@@ -239,41 +243,77 @@ msgid ""
 msgstr ""
 "下载域名规则所需要的域名列表文件和smartdns配置文件，下载完成后刷新页面。"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:240
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:1013
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:241
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:1040
 msgid "Dual-stack IP Selection"
 msgstr "双栈IP优选"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:142
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:371
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:648
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:965
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:143
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:372
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:675
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:992
 msgid "Enable"
 msgstr "启用"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:495
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:496
 msgid "Enable Auto Update"
 msgstr "启用自动更新"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:241
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:1014
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:242
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:1041
 msgid "Enable IP selection between IPV4 and IPV6"
 msgstr "启用 IPV4 和 IPV6 间的 IP 优选策略。"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:224
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:225
 msgid "Enable IPV6 DNS Server"
 msgstr "启用IPV6服务器。"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:219
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:384
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:220
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:385
 msgid "Enable TCP DNS Server"
 msgstr "启用TCP服务器。"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:495
-msgid "Enable daily auto update."
-msgstr "启用每日自动更新"
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:496
+msgid "Enable daily(week) auto update."
+msgstr "启用每日（每周）自动更新"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:500
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:501
+msgid "Update time (every day)"
+msgstr "更新时间(每周)"
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:502
+msgid "Every Day"
+msgstr "每天"
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:503
+msgid "Every Monday"
+msgstr "每周一"
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:504
+msgid "Every Tuesday"
+msgstr "每周二"
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:505
+msgid "Every Wednesday"
+msgstr "每周三"
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:506
+msgid "Every Thursday"
+msgstr "每周四"
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:507
+msgid "Every Friday"
+msgstr "每周五"
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:508
+msgid "Every Saturday"
+msgstr "每周六"
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:509
+msgid "Every Sunday"
+msgstr "每周日"
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:513
 msgid "Update time (every day)"
 msgstr "更新时间(每天)"
 
@@ -289,40 +329,40 @@ msgstr "是否启用第二DNS服务器。"
 msgid "Enable or disable smartdns server"
 msgstr "启用或禁用SmartDNS服务"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:700
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:727
 msgid "Exclude DNS Server from default group."
 msgstr "从default默认服务器组中排除。"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:700
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:727
 msgid "Exclude Default Group"
 msgstr "从默认组中排除"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:215
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:216
 msgid "Fastest IP"
 msgstr "最快IP"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:216
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:217
 msgid "Fastest Response"
 msgstr "最快响应"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:541
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:554
 msgid "File Name"
 msgstr "文件名"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:560
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:573
 msgid "File Type"
 msgstr "文件类型"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:708
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:735
 msgid "Filtering IP with blacklist"
 msgstr "使用IP黑名单过滤"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:214
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:215
 msgid "First Ping"
 msgstr "最快PING"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:272
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:436
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:273
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:437
 #: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:848
 #: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:1062
 msgid "Force AAAA SOA"
@@ -330,30 +370,30 @@ msgstr "停用IPV6地址解析"
 
 #: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:272
 #: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:436
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:848
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:1062
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:875
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:1089
 msgid "Force AAAA SOA."
 msgstr "停用IPV6地址解析。"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:277
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:278
 msgid "Force HTTPS SOA"
 msgstr "停用HTTPS地址解析"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:277
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:278
 msgid "Force HTTPS SOA."
 msgstr "停用HTTPS地址解析。"
 
 #: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:128
 #: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:131
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:644
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:671
 msgid "General Settings"
 msgstr "常规设置"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:605
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:618
 msgid "Generate Coredump"
 msgstr "生成coredump"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:606
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:619
 msgid ""
 "Generate Coredump file when smartdns crash, coredump file is located at /tmp/"
 "smartdns.xxx.core."
@@ -364,43 +404,43 @@ msgstr ""
 msgid "Grant access to LuCI app smartdns"
 msgstr "授予访问 LuCI 应用 smartdns 的权限"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:743
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:770
 msgid "HTTP Host"
 msgstr "HTTP主机"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:814
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:841
 msgid "IP Blacklist"
 msgstr "IP黑名单"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:707
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:734
 msgid "IP Blacklist Filtering"
 msgstr "IP黑名单过滤"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:224
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:225
 msgid "IPV6 Server"
 msgstr "IPV6服务器"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:440
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:852
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:1068
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:441
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:879
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:1095
 msgid "IPset Name"
 msgstr "IPset名称"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:440
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:852
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:1068
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:441
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:879
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:1095
 msgid "IPset name."
 msgstr "IPset名称。"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:1144
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:1171
 msgid "If you like this software, please buy me a cup of coffee."
 msgstr "如果本软件对你有帮助，请给作者加个蛋。"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:353
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:354
 msgid "Include Config Files<br>/etc/smartdns/conf.d"
 msgstr "包含配置文件<br>/etc/smartdns/conf.d"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:354
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:355
 msgid ""
 "Include other config files from /etc/smartdns/conf.d or custom path, can be "
 "downloaded from the download page."
@@ -408,67 +448,72 @@ msgstr ""
 "包含配置文件，路径为/etc/smartdns/conf.d，或自定义配置文件路径，可以从下载页"
 "配置自动下载。"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:283
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:284
 msgid "Ipset name, Add domain result to ipset when speed check fails."
 msgstr "IPset名称，当测速失败时，将查询到的结果添加到对应的IPSet集合中。"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:533
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:546
 msgid "List of files to download."
 msgstr "下载文件列表。"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:229
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:230
 msgid "Listen only on the specified interfaces."
 msgstr "监听在指定的设备上，避免非本地网络的DNS查询请求。"
 
 #: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:153
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:377
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:378
 msgid "Local Port"
 msgstr "本地端口"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:630
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:650
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:658
+msgid "View Log"
+msgstr "查看日志"
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:646
 msgid "Log File"
 msgstr "日志文件路径"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:614
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:630
 msgid "Log Level"
 msgstr "日志级别"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:626
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:642
 msgid "Log Number"
 msgstr "日志数量"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:610
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:626
 msgid "Log Size"
 msgstr "日志大小"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:763
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:790
 msgid "Marking Packets"
 msgstr "数据包标记"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:337
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:338
 msgid "Maximum TTL for all domain result."
 msgstr "所有域名的最大 TTL 值。"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:329
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:330
 msgid "Minimum TTL for all domain result."
 msgstr "所有域名的最小 TTL 值。"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:459
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:871
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:1074
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:460
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:898
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:1101
 msgid "NFTset Name"
 msgstr "NFTSet名称"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:316
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:471
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:883
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:1090
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:317
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:472
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:910
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:1117
 msgid "NFTset name format error, format: [#[4|6]:[family#table#set]]"
 msgstr "NFTSet名称格式错误，格式：[#[4|6]:[family#table#set]]"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:459
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:871
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:1074
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:460
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:898
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:1101
 msgid "NFTset name, format: [#[4|6]:[family#table#set]]"
 msgstr "NFTSet名称，格式：[#[4|6]:[family#table#set]]"
 
@@ -476,47 +521,47 @@ msgstr "NFTSet名称，格式：[#[4|6]:[family#table#set]]"
 msgid "NOT RUNNING"
 msgstr "未运行"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:234
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:235
 msgid "Name of device name listen on."
 msgstr "绑定的设备名称。"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:304
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:305
 msgid ""
 "Nftset name, Add domain result to nftset when speed check fails, format: "
 "[#[4|6]:[family#table#set]]"
 msgstr "NFTset名称，当测速失败时，将查询到的结果添加到对应的NFTSet集合中。"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:1020
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:1047
 msgid "No"
 msgstr "否"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:282
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:283
 msgid "No Speed IPset Name"
 msgstr "无速度时IPSet名称"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:303
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:304
 msgid "No Speed NFTset Name"
 msgstr "无速度时NFTSet名称"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:724
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:751
 msgid "No check certificate"
 msgstr "停用证书校验"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:177
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:1006
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:1031
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:178
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:1033
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:1058
 msgid "None"
 msgstr "无"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:790
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:817
 msgid "Only socks5 proxy support udp server."
 msgstr "仅SOCKS5代理支持UDP服务器。"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:786
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:813
 msgid "Please set proxy server first."
 msgstr "请先设置代理服务器。"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:572
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:586
 msgid "Proxy Server"
 msgstr "代理服务器"
 
@@ -524,16 +569,16 @@ msgstr "代理服务器"
 msgid "Proxy Server Settings"
 msgstr "代理服务器设置"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:573
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:586
 msgid "Proxy Server URL, format: [socks5|http]://user:pass@ip:port."
 msgstr "代理服务器地址，格式：[socks5|http]://user:pass@ip:port。"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:561
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:574
 msgid ""
 "Proxy server URL format error, format: [socks5|http]://user:pass@ip:port."
 msgstr "代理服务器地址格式错误，格式：[socks5|http]://user:pass@ip:port。"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:390
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:391
 msgid "Query DNS through specific dns server group, such as office, home."
 msgstr "使用指定服务器组查询，比如office, home。"
 
@@ -541,36 +586,36 @@ msgstr "使用指定服务器组查询，比如office, home。"
 msgid "RUNNING"
 msgstr "运行中"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:341
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:342
 msgid "Reply Domain TTL Max"
 msgstr "回应的域名TTL最大值"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:342
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:343
 msgid "Reply maximum TTL for all domain result."
 msgstr "设置返回给客户端的域名TTL最大值。"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:1156
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:1157
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:1183
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:1184
 msgid "Report bugs"
 msgstr "报告BUG"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:267
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:268
 msgid "Resolve Local Hostnames"
 msgstr "解析本地主机名"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:267
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:268
 msgid "Resolve local hostnames by reading Dnsmasq lease file."
 msgstr "读取Dnsmasq的租约文件解析本地主机名。"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:209
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:210
 msgid "Response Mode"
 msgstr "响应模式"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:1180
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:1207
 msgid "Restart"
 msgstr "重启"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:1171
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:1198
 msgid "Restart Service"
 msgstr "重启服务"
 
@@ -578,53 +623,53 @@ msgstr "重启服务"
 msgid "Second Server Settings"
 msgstr "第二DNS服务器"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:252
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:253
 msgid "Serve expired"
 msgstr "缓存过期服务"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:389
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:681
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:819
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:973
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:390
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:708
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:846
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:1000
 msgid "Server Group"
 msgstr "服务器组"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:839
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:993
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:867
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:1007
 msgid "Server Group %s not exists"
 msgstr "服务器组%s不存在"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:147
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:148
 msgid "Server Name"
 msgstr "服务器名称"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:813
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:840
 msgid "Set Specific domain ip address."
 msgstr "设置指定域名的IP地址。"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:812
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:839
 msgid "Set Specific domain rule list."
 msgstr "设置指定域名的规则列表。"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:814
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:841
 msgid "Set Specific ip blacklist."
 msgstr "设置指定的 IP 黑名单列表。"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:715
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:742
 msgid "Set TLS hostname to verify."
 msgstr "设置校验TLS主机名。"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:764
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:791
 msgid "Set mark on packets."
 msgstr "设置数据包标记。"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:744
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:771
 msgid ""
 "Set the HTTP host used for the query. Use this parameter when the host of "
 "the URL address is an IP address."
 msgstr "设置查询时使用的HTTP主机，当URL地址的host是IP地址时，使用此参数。"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:734
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:761
 msgid "Sets the server name indication for query. '-' for disable SNI name."
 msgstr "设置服务器SNI名称，‘-’表示禁用SNI名称。"
 
@@ -632,56 +677,56 @@ msgstr "设置服务器SNI名称，‘-’表示禁用SNI名称。"
 msgid "Settings"
 msgstr "设置"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:402
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:403
 msgid "Skip Address Rules"
 msgstr "跳过address规则"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:431
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:432
 msgid "Skip Cache"
 msgstr "跳过cache"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:431
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:432
 msgid "Skip Cache."
 msgstr "跳过cache。"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:425
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:426
 msgid "Skip Dualstack Selection"
 msgstr "跳过双栈优选"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:426
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:427
 msgid "Skip Dualstack Selection."
 msgstr "跳过双栈优选。"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:414
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:415
 msgid "Skip Ipset Rule"
 msgstr "跳过ipset规则"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:408
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:409
 msgid "Skip Nameserver Rule"
 msgstr "跳过Nameserver规则"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:420
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:421
 msgid "Skip SOA Address Rule"
 msgstr "跳过address SOA(#)规则"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:421
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:422
 msgid "Skip SOA address rules."
 msgstr "跳过address SOA(#)规则。"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:396
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:843
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:397
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:870
 msgid "Skip Speed Check"
 msgstr "跳过测速"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:403
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:404
 msgid "Skip address rules."
 msgstr "跳过address规则。"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:415
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:416
 msgid "Skip ipset rules."
 msgstr "跳过ipset规则。"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:409
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:410
 msgid "Skip nameserver rules."
 msgstr "跳过Nameserver规则。"
 
@@ -700,22 +745,22 @@ msgid ""
 "IP, supports ad filtering, and supports avoiding DNS poisoning."
 msgstr "SmartDNS是一个本地高性能DNS服务器，支持返回最快IP，支持广告过滤。"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:1148
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:1175
 msgid "SmartDNS official website"
 msgstr "SmartDNS官方网站"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:377
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:378
 msgid "Smartdns local server port"
 msgstr "SmartDNS本地服务端口"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:154
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:155
 msgid ""
 "Smartdns local server port, smartdns will be automatically set as main dns "
 "when the port is 53."
 msgstr ""
 "SmartDNS本地服务端口，当端口号设置为53时，smartdns将会自动配置为主dns。"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:210
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:211
 msgid ""
 "Smartdns response mode, First Ping: return the first ping IP, Fastest IP: "
 "return the fastest IP, Fastest Response: return the fastest DNS response."
@@ -723,16 +768,16 @@ msgstr ""
 "SmartDNS响应模式，最快PING： 返回最早有ping结果的IP，速度适中；最快IP： 返回"
 "最快IP，查询请求可能延长； 最快响应：返回最快响应的结果，查询请求时间短。"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:147
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:148
 msgid "Smartdns server name"
 msgstr "SmartDNS的服务器名称，默认为smartdns，留空为主机名"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:169
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:1022
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:170
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:1049
 msgid "Smartdns speed check mode."
 msgstr "SmartDNS测速模式。"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:1125
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:1152
 msgid ""
 "Specify an IP address to return for any host in the given domains, Queries "
 "in the domains are never forwarded and always replied to with the specified "
@@ -741,94 +786,94 @@ msgstr ""
 "配置特定域名返回特定的IP地址，域名查询将不到上游服务器请求，直接返回配置的IP"
 "地址，可用于广告屏蔽。"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:169
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:1022
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:170
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:1049
 msgid "Speed Check Mode"
 msgstr "测速模式"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:202
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:1056
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:203
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:1083
 msgid "Speed check mode is invalid."
 msgstr "测速模式无效。"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:219
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:384
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:220
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:385
 msgid "TCP Server"
 msgstr "TCP服务器"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:196
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:1050
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:197
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:1077
 msgid "TCP port is empty"
 msgstr "TCP端口号为空"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:714
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:741
 msgid "TLS Hostname Verify"
 msgstr "校验TLS主机名"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:733
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:760
 msgid "TLS SNI name"
 msgstr "TLS SNI名称"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:752
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:779
 msgid "TLS SPKI Pinning"
 msgstr "TLS SPKI 指纹"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:324
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:325
 msgid "TTL for all domain result."
 msgstr "设置所有域名的 TTL 值。"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:1143
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:1170
 msgid "Technical Support"
 msgstr "技术支持"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:545
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:558
 msgid "URL"
 msgstr "URL"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:554
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:567
 msgid "URL format error, format: http:// or https://"
 msgstr "URL格式错误，格式：http://或https://"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:529
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:542
 msgid "Update"
 msgstr "更新"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:508
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:533
 msgid "Update Files"
 msgstr "更新文件"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:506
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:519
 msgid "Upload Config File"
 msgstr "上传配置文件"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:513
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:526
 msgid "Upload Domain List File"
 msgstr "上传域名列表文件"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:514
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:527
 msgid "Upload domain list file to /etc/smartdns/domain-set"
 msgstr "上传域名列表文件到/etc/smartdns/domain-set"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:898
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:998
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:925
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:1025
 msgid ""
 "Upload domain list file, or configure auto download from Download File "
 "Setting page."
 msgstr "上传域名列表文件，或在下载文件设置页面设置自动下载。"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:926
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:953
 msgid "Upload domain list file."
 msgstr "上传域名列表文件"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:507
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:520
 msgid "Upload smartdns config file to /etc/smartdns/conf.d"
 msgstr "上传配置文件到/etc/smartdns/conf.d"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:637
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:664
 msgid "Upstream Servers"
 msgstr "上游服务器"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:638
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:665
 msgid ""
 "Upstream Servers, support UDP, TCP protocol. Please configure multiple DNS "
 "servers, including multiple foreign DNS servers."
@@ -836,15 +881,15 @@ msgstr ""
 "上游 DNS 服务器，支持 UDP，TCP 协议。请配置多个上游 DNS 服务器，包括多个国内"
 "外服务器。"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:771
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:798
 msgid "Use Proxy"
 msgstr "使用代理"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:772
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:799
 msgid "Use proxy to connect to upstream DNS server."
 msgstr "使用代理连接上游DNS服务器。"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:753
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:780
 msgid ""
 "Used to verify the validity of the TLS server, The value is Base64 encoded "
 "SPKI fingerprint, leaving blank to indicate that the validity of TLS is not "
@@ -853,69 +898,69 @@ msgstr ""
 "用于校验 TLS 服务器的有效性，数值为 Base64 编码的 SPKI 指纹，留空表示不验证 "
 "TLS 的合法性。"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:262
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:263
 msgid "Write cache to disk on exit and load on startup."
 msgstr "退出时保存cache到磁盘，启动时加载。"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:1019
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:1046
 msgid "Yes"
 msgstr "是"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:172
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:213
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:617
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:1018
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:1026
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:173
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:214
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:633
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:1045
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:1053
 msgid "default"
 msgstr "默认"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:561
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:574
 msgid "domain list (/etc/smartdns/domain-set)"
 msgstr "域名列表（/etc/smartdns/domain-set）"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:676
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:703
 msgid "https"
 msgstr "https"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:657
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:684
 msgid "ip"
 msgstr "ip"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:295
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:452
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:864
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:296
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:453
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:891
 msgid "ipset name format error, format: [#[4|6]:]ipsetname"
 msgstr "IPset名称格式错误，格式：[#[4|6]:]ipsetname"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:1149
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:1176
 msgid "open website"
 msgstr "打开网站"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:662
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:689
 msgid "port"
 msgstr "端口"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:562
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:575
 msgid "smartdns config (/etc/smartdns/conf.d)"
 msgstr "smartdns 配置文件（/etc/smartdns/conf.d）"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:591
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:604
 msgid "smartdns custom settings"
 msgstr "smartdns 自定义设置，具体配置参数参考指导"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:674
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:701
 msgid "tcp"
 msgstr "tcp"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:675
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:702
 msgid "tls"
 msgstr "tls"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:560
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:671
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:573
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:698
 msgid "type"
 msgstr "类型"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:683
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:710
 msgid "udp"
 msgstr "udp"

--- a/root/usr/libexec/smartdns-call
+++ b/root/usr/libexec/smartdns-call
@@ -8,11 +8,14 @@ list_file="${log_file:-/var/log/smartdns/smartdns.log}"
 
 case "$action" in
         tail)
-        # 读取日志
+              if [ ! -e "$list_file" ]; then
+                echo "Log file does not exist."
+              fi
+        # read log
               tail -n 5000 "$list_file"
         ;;
         clear_log)
-        # 清空日志
+        # clear log
               > $list_file
         ;;
 esac

--- a/root/usr/libexec/smartdns-call
+++ b/root/usr/libexec/smartdns-call
@@ -1,4 +1,7 @@
 #!/bin/sh
+# 
+# Copyright 2018-2020 Nick Peng <zxlhhyccc@gmail.com>
+# Licensed to the public under the GPL V3 License.
 
 action=$1
 shift

--- a/root/usr/libexec/smartdns-call
+++ b/root/usr/libexec/smartdns-call
@@ -1,0 +1,18 @@
+#!/bin/sh
+
+action=$1
+shift
+
+log_file="$(uci -q get smartdns.@smartdns[0].log_file)"
+list_file="${log_file:-/var/log/smartdns/smartdns.log}"
+
+case "$action" in
+        tail)
+        # 读取日志
+              tail -n 5000 "$list_file"
+        ;;
+        clear_log)
+        # 清空日志
+              > $list_file
+        ;;
+esac

--- a/root/usr/share/luci/menu.d/luci-app-smartdns.json
+++ b/root/usr/share/luci/menu.d/luci-app-smartdns.json
@@ -1,12 +1,21 @@
 {
 	"admin/services/smartdns": {
 		"title": "SmartDNS",
+		"order": 60,
 		"action": {
 			"type": "view",
 			"path": "smartdns/smartdns"
 		},
 		"depends": {
+			"acl": [ "luci-app-smartdns" ],
 			"uci": { "smartdns": true }
+		}
+	},
+
+	"admin/services/smartdns/log": {
+		"action": {
+			"type": "view",
+			"path": "smartdns/log"
 		}
 	}
 }

--- a/root/usr/share/rpcd/acl.d/luci-app-smartdns.json
+++ b/root/usr/share/rpcd/acl.d/luci-app-smartdns.json
@@ -2,8 +2,11 @@
 	"luci-app-smartdns": {
 		"description": "Grant access to LuCI app smartdns",
 		"read": {
+			"cgi-io": [ "exec" ],
 			"file": {
-				"/etc/smartdns/*": [ "read" ]
+				"/etc/smartdns/*": [ "read" ],
+				"/usr/libexec/smartdns-call tail": [ "exec" ],
+				"/usr/libexec/smartdns-call clear_log": [ "exec" ]
 			},
 			"ubus": {
 				"service": [ "list" ]


### PR DESCRIPTION
1、Currently, logs can only be viewed through ssh. After front-end logs are displayed, you can view them more easily；
2、At present, it is only updated daily, and under normal circumstances, the data updated daily is not large, so the addition can be updated weekly or daily.