### PR TITLE
Revert "luci: Fix the issue of logging in for non-IP addresses."

### DIFF
--- a/htdocs/luci-static/resources/view/smartdns/smartdns.js
+++ b/htdocs/luci-static/resources/view/smartdns/smartdns.js
@@ -68,9 +68,7 @@ function smartdnsRenderStatus(res) {
 		renderHTML += "<span style=\"color:green;font-weight:bold\">SmartDNS - " + _("RUNNING") + "</span>";
 
 		if (uiEnable === '1') {
-			var protocol = window.location.protocol;
-			var hostname = window.location.hostname;
-			var uiLink = protocol + "//" + hostname + ":" + uiPort;
+			var uiLink = "http://" + window.location.hostname + ":" + uiPort + "/";
 			renderHTML += "&#160; <a class=\"btn cbi-button\" style=\"margin-left: 10px; background-color: black; color: white; border-color: #333;\" href=\"" + uiLink + "\" target=\"_blank\">" + _("Open the WebUI") + "</a>";
 		}
 	} else {


### PR DESCRIPTION
This reverts commit 26e7e2973c21fec8b35266073ef7cf8bc2ac0396.
原提交目的是：`除比如: http://192.168.1.1:6080/ 登录外，也可比如：http://openwrt.lan:6080/ 登录。`
但我怀疑提交者根本没有看清楚原本的代码意思，原本的代码是：`var uiLink = "http://" + window.location.hostname + ":" + uiPort + "/";` ，` window.location.hostname`本就能取到中间hostname部分。
而提交者PR的代码跟原代码相比只不过增加了用`window.location.protocol`代替了`http:`，这会导致一个很大的问题，如果路由开启了tls证书登录，那么window.location.protocol获取到的就是https，但目前smartdns-ui并不支持https，会打不开ui页面。

@pymumu 